### PR TITLE
Fix error when running brew tap on case-sensitive macOS

### DIFF
--- a/x86_64-none-elf.rb
+++ b/x86_64-none-elf.rb
@@ -1,4 +1,4 @@
-require "FileUtils"
+require "fileutils"
 
 class X8664NoneElf < Formula
   desc "x86_64 ELF toolchain and cross-compiler for OS X"


### PR DESCRIPTION
When I try to tap osxct, brew complained as following:

```
Updating Homebrew...
==> Tapping sergiobenitez/osxct
Cloning into '/usr/local/Homebrew/Library/Taps/sergiobenitez/homebrew-osxct'...
remote: Counting objects: 7, done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 7 (delta 1), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (7/7), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/sergiobenitez/homebrew-osxct/x86_64-none-elf.rb
x86_64-none-elf: cannot load such file -- FileUtils
Error: Cannot tap sergiobenitez/osxct: invalid syntax in tap!
```

In short, **ruby fails to  find FileUtils**. 

Example on [FileUtils](https://ruby-doc.org/stdlib-2.4.1/libdoc/fileutils/rdoc/FileUtils.htmll) show that fileutils should be lowercase when writing require statement. My macOS is installed on a **case-sensitive** file system, and  thus FileUtils is **different** from fileutils.

After altering FileUtils into lowercase, I finally managed to tapped osxct on my case-sensitive macOS.

On **case-insensitive** file system, this doesn't matter. 